### PR TITLE
Add solar zenith, elevation, and azimuth calculations

### DIFF
--- a/Source/Solar Calculator Solution/Innovative.SolarCalculator/SolarTimes.cs
+++ b/Source/Solar Calculator Solution/Innovative.SolarCalculator/SolarTimes.cs
@@ -1,4 +1,4 @@
-﻿// ***
+// ***
 // *** Copyright (C) 2013-2017, Daniel M. Porrey.  All rights reserved.
 // *** Written By Daniel M. Porrey
 // ***
@@ -513,6 +513,46 @@ namespace Innovative.SolarCalculator
 				returnValue = DecimalTimeSpan.FromMinutes(8M * this.HourAngleSunrise);
 
 				return returnValue;
+			}
+		}
+
+		/// <summary>
+		/// Hour Angle (degrees)
+		/// (Spreadsheet Column AC)
+		/// </summary>
+		public Angle HourAngleDegrees
+		{
+			get
+			{
+				var temp = this.TrueSolarTime / 4;
+				return temp < 0 ? temp + 180 : temp - 180;
+			}
+		}
+
+		/// <summary>
+		/// Solar Zenith (degrees)
+		/// (Spreadsheet Column AD)
+		/// </summary>
+		public Angle SolarZenith
+		{
+			get
+			{
+				return Angle.FromRadians(
+					Universal.Math.Acos(Universal.Math.Sin(this.Latitude.Radians) * Universal.Math.Sin(this.SolarDeclination.Radians) +
+					Universal.Math.Cos(this.Latitude.Radians) * Universal.Math.Cos(this.SolarDeclination.Radians) *  Universal.Math.Cos(this.HourAngleDegrees.Radians))
+					);
+			}
+		}
+
+		/// <summary>
+		/// Solar Elevation (degrees)
+		/// (Spreadsheet Column AE)
+		/// </summary>
+		public Angle SolarElevation
+		{
+			get
+			{
+				return new Angle(90) - this.SolarZenith;
 			}
 		}
 		#endregion

--- a/Source/Solar Calculator Solution/Innovative.SolarCalculator/SolarTimes.cs
+++ b/Source/Solar Calculator Solution/Innovative.SolarCalculator/SolarTimes.cs
@@ -1,4 +1,4 @@
-// ***
+﻿// ***
 // *** Copyright (C) 2013-2017, Daniel M. Porrey.  All rights reserved.
 // *** Written By Daniel M. Porrey
 // ***
@@ -553,6 +553,29 @@ namespace Innovative.SolarCalculator
 			get
 			{
 				return new Angle(90) - this.SolarZenith;
+			}
+		}
+
+		/// <summary>
+		/// Solar Azimuth (degrees)
+		/// (Spreadsheet Column AH)
+		/// </summary>
+		public Angle SolarAzimuth
+		{
+			get
+			{
+				var angle = Angle.FromRadians(Universal.Math.Acos(
+						((Universal.Math.Sin(this.Latitude.Radians) * Universal.Math.Cos(this.SolarZenith.Radians)) - 
+							Universal.Math.Sin(this.SolarDeclination.Radians)) /
+					 	(Universal.Math.Cos(this.Latitude.Radians) * Universal.Math.Sin(this.SolarZenith.Radians))));
+				if(this.HourAngleDegrees > 0.0)
+				{
+					return Angle.Reduce(angle + new Angle(180.0));
+				}
+				else
+				{
+					return Angle.Reduce(new Angle(540.0) - angle);
+				}
 			}
 		}
 		#endregion


### PR DESCRIPTION
This pull request adds calculations for solar zenith, elevation, and azimuth. It also adds HourAngleDegrees (column AC), which is used to calculate zenith and azimuth.

Apologies for the omitted tests - I could not run the test solutions in VS Code with .net core. I would be happy to contribute xunit tests for these calculations. In lieu of tests, I manually verified the output.