### PR TITLE
Remove unnecessary DateTime parsing for internationalization

### DIFF
--- a/Source/Solar Calculator Solution/Innovative.SolarCalculator/ExcelFormulae.cs
+++ b/Source/Solar Calculator Solution/Innovative.SolarCalculator/ExcelFormulae.cs
@@ -37,7 +37,7 @@ namespace Innovative.SolarCalculator
 		{
 			decimal returnValue = 0;
 
-			if (value.Date <= DateTime.Parse("1/1/1900"))
+			if (value.Date <= new DateTime(1900, 1, 1))
 			{
 				decimal d = value.ToOleAutomationDate();
 				decimal c = (decimal)Math.Floor((double)d);

--- a/Source/Solar Calculator Solution/Innovative.SolarCalculator/SolarTimes.cs
+++ b/Source/Solar Calculator Solution/Innovative.SolarCalculator/SolarTimes.cs
@@ -225,7 +225,7 @@ namespace Innovative.SolarCalculator
 				// ***
 				// *** .1 / 24
 				// ***
-				returnValue = DateTime.Parse("12/30/1899  12:00:00 AM").Add(this.ForDate.TimeOfDay).ToOleAutomationDate();
+				returnValue = (new DateTime(1899, 12, 30, 0, 0, 0)).Add(this.ForDate.TimeOfDay).ToOleAutomationDate();
 
 				return returnValue;
 			}


### PR DESCRIPTION
Parsing dates in the format MM/DD/YYYY does not work reliably across all locales, so I removed unnecessary parsing of strings to DateTime objects. This should fix a bug in my app which uses uses the Solar Calculator library: https://github.com/t1m0thyj/WinDynamicDesktop/issues/67