### PR TITLE
Support for polar day/night

### DIFF
--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Helpers/TestDirector.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Helpers/TestDirector.cs
@@ -41,28 +41,28 @@ namespace Innovative.SolarCalculator.Tests
 						   {
 							   Date = DateTime.Parse(tbl["Date"], new CultureInfo("en-US")),
 							   Time = DateTime.Parse(tbl["Time"], new CultureInfo("en-US")),
-							   TimeZoneOffset = Convert.ToInt32(tbl["TimeZoneOffset"]),
-							   Latitude = Convert.ToDecimal(tbl["Latitude"]),
-							   Longitude = Convert.ToDecimal(tbl["Longitude"]),
-							   JulianDay = Convert.ToDecimal(tbl["JulianDay"]),
-							   JulianCentury = Convert.ToDecimal(tbl["JulianCentury"]),
-							   GeomMeanLongSun = Convert.ToDecimal(tbl["GeomMeanLongSun"]),
-							   GeomMeanAnomSun = Convert.ToDecimal(tbl["GeomMeanAnomSun"]),
-							   EccentEarthOrbit = Convert.ToDecimal(tbl["EccentEarthOrbit"]),
-							   SunEqofCtr = Convert.ToDecimal(tbl["SunEqofCtr"]),
-							   SunTrueLong = Convert.ToDecimal(tbl["SunTrueLong"]),
-							   SunAppLong = Convert.ToDecimal(tbl["SunAppLong"]),
-							   MeanObliqEcliptic = Convert.ToDecimal(tbl["MeanObliqEcliptic"]),
-							   ObliqCorr = Convert.ToDecimal(tbl["ObliqCorr"]),
-							   SunDeclin = Convert.ToDecimal(tbl["SunDeclin"]),
-							   Vary = Convert.ToDecimal(tbl["vary"]),
-							   EqofTime = Convert.ToDecimal(tbl["EqofTime"]),
-							   HaSunrise = Convert.ToDecimal(tbl["HaSunrise"]),
+							   TimeZoneOffset = Convert.ToInt32(tbl["TimeZoneOffset"], new CultureInfo("en-US")),
+							   Latitude = Convert.ToDecimal(tbl["Latitude"], new CultureInfo("en-US")),
+							   Longitude = Convert.ToDecimal(tbl["Longitude"], new CultureInfo("en-US")),
+							   JulianDay = Convert.ToDecimal(tbl["JulianDay"], new CultureInfo("en-US")),
+							   JulianCentury = Convert.ToDecimal(tbl["JulianCentury"], new CultureInfo("en-US")),
+							   GeomMeanLongSun = Convert.ToDecimal(tbl["GeomMeanLongSun"], new CultureInfo("en-US")),
+							   GeomMeanAnomSun = Convert.ToDecimal(tbl["GeomMeanAnomSun"], new CultureInfo("en-US")),
+							   EccentEarthOrbit = Convert.ToDecimal(tbl["EccentEarthOrbit"], new CultureInfo("en-US")),
+							   SunEqofCtr = Convert.ToDecimal(tbl["SunEqofCtr"], new CultureInfo("en-US")),
+							   SunTrueLong = Convert.ToDecimal(tbl["SunTrueLong"], new CultureInfo("en-US")),
+							   SunAppLong = Convert.ToDecimal(tbl["SunAppLong"], new CultureInfo("en-US")),
+							   MeanObliqEcliptic = Convert.ToDecimal(tbl["MeanObliqEcliptic"], new CultureInfo("en-US")),
+							   ObliqCorr = Convert.ToDecimal(tbl["ObliqCorr"], new CultureInfo("en-US")),
+							   SunDeclin = Convert.ToDecimal(tbl["SunDeclin"], new CultureInfo("en-US")),
+							   Vary = Convert.ToDecimal(tbl["vary"], new CultureInfo("en-US")),
+							   EqofTime = Convert.ToDecimal(tbl["EqofTime"], new CultureInfo("en-US")),
+							   HaSunrise = Convert.ToDecimal(tbl["HaSunrise"], new CultureInfo("en-US")),
 							   SolarNoon = DateTime.Parse(tbl["SolarNoon"], new CultureInfo("en-US")),
 							   SunriseTime = DateTime.Parse(tbl["SunriseTime"], new CultureInfo("en-US")),
 							   SunsetTime = DateTime.Parse(tbl["SunsetTime"], new CultureInfo("en-US")),
-							   SunlightDuration = Convert.ToDouble(tbl["SunlightDuration"]),
-							   TrueSolarTime = Convert.ToDecimal(tbl["TrueSolarTime"])
+							   SunlightDuration = Convert.ToDouble(tbl["SunlightDuration"], new CultureInfo("en-US")),
+							   TrueSolarTime = Convert.ToDecimal(tbl["TrueSolarTime"], new CultureInfo("en-US"))
 						   }).ToArray();
 
 			return returnValue;
@@ -81,7 +81,7 @@ namespace Innovative.SolarCalculator.Tests
 						   select new DateValueTestData()
 						   {
 							   Date = DateTime.Parse(tbl["Date"], new CultureInfo("en-US")),
-							   DateValue = Convert.ToDecimal(tbl["DateValue"])
+							   DateValue = Convert.ToDecimal(tbl["DateValue"], new CultureInfo("en-US"))
 						   }).ToArray();
 
 			return returnValue;
@@ -99,17 +99,17 @@ namespace Innovative.SolarCalculator.Tests
 			returnValue = (from tbl in TestDirector.ParseCsv(contents)
 						   select new CsharpExcelTestData()
 						   {
-							   Value1 = Convert.ToDecimal(tbl["Value1"]),
-							   Value2 = Convert.ToDecimal(tbl["Value2"]),
-							   Value3 = Convert.ToDecimal(tbl["Value3"]),
-							   Radians = Convert.ToDecimal(tbl["Radians"]),
-							   Degrees = Convert.ToDecimal(tbl["Degrees"]),
-							   Mod = Convert.ToDecimal(tbl["Mod"]),
-							   Sin = Convert.ToDecimal(tbl["Sin"]),
-							   Asin = Convert.ToDecimal(tbl["Asin"]),
-							   Cos = Convert.ToDecimal(tbl["Cos"]),
-							   Acos = Convert.ToDecimal(tbl["Acos"]),
-							   Tan = Convert.ToDecimal(tbl["Tan"])
+							   Value1 = Convert.ToDecimal(tbl["Value1"], new CultureInfo("en-US")),
+							   Value2 = Convert.ToDecimal(tbl["Value2"], new CultureInfo("en-US")),
+							   Value3 = Convert.ToDecimal(tbl["Value3"], new CultureInfo("en-US")),
+							   Radians = Convert.ToDecimal(tbl["Radians"], new CultureInfo("en-US")),
+							   Degrees = Convert.ToDecimal(tbl["Degrees"], new CultureInfo("en-US")),
+							   Mod = Convert.ToDecimal(tbl["Mod"], new CultureInfo("en-US")),
+							   Sin = Convert.ToDecimal(tbl["Sin"], new CultureInfo("en-US")),
+							   Asin = Convert.ToDecimal(tbl["Asin"], new CultureInfo("en-US")),
+							   Cos = Convert.ToDecimal(tbl["Cos"], new CultureInfo("en-US")),
+							   Acos = Convert.ToDecimal(tbl["Acos"], new CultureInfo("en-US")),
+							   Tan = Convert.ToDecimal(tbl["Tan"], new CultureInfo("en-US"))
 						   }).ToArray();
 
 			return returnValue;
@@ -127,21 +127,21 @@ namespace Innovative.SolarCalculator.Tests
 			returnValue = (from tbl in TestDirector.ParseCsv(contents)
 						   select new AngleTestData()
 						   {
-							   Angle = Convert.ToDecimal(tbl["Angle2"]),
-							   Radians = Convert.ToDecimal(tbl["Radians"]),
-							   Degrees = Convert.ToDecimal(tbl["Degrees"]),
-							   DecimalMinutes = Convert.ToDecimal(tbl["DecimalMinutes"]),
-							   Arcminute = Convert.ToDecimal(tbl["Arcminute"]),
-							   Arcsecond = Convert.ToDecimal(tbl["Arcsecond"]),
+							   Angle = Convert.ToDecimal(tbl["Angle2"], new CultureInfo("en-US")),
+							   Radians = Convert.ToDecimal(tbl["Radians"], new CultureInfo("en-US")),
+							   Degrees = Convert.ToDecimal(tbl["Degrees"], new CultureInfo("en-US")),
+							   DecimalMinutes = Convert.ToDecimal(tbl["DecimalMinutes"], new CultureInfo("en-US")),
+							   Arcminute = Convert.ToDecimal(tbl["Arcminute"], new CultureInfo("en-US")),
+							   Arcsecond = Convert.ToDecimal(tbl["Arcsecond"], new CultureInfo("en-US")),
 							   LongFormat = tbl["LongFormat"],
 							   ShortFormat = tbl["ShortFormat"],
-							   RandomNumber = Convert.ToDecimal(tbl["RandomNumber"]),
-							   RadiansMultiplied = Convert.ToDecimal(tbl["RadiansMultiplied"]),
-							   RadiansDivided = Convert.ToDecimal(tbl["RadiansDivided"]),
-							   ReducedDegrees = Convert.ToDecimal(tbl["ReducedDegrees"]),
-							   TotalMinutes = Convert.ToDecimal(tbl["TotalMinutes"]),
-							   TotalSeconds = Convert.ToDecimal(tbl["TotalSeconds"]),
-							   OppositeDirection = Convert.ToDecimal(tbl["OppositeDirection"])
+							   RandomNumber = Convert.ToDecimal(tbl["RandomNumber"], new CultureInfo("en-US")),
+							   RadiansMultiplied = Convert.ToDecimal(tbl["RadiansMultiplied"], new CultureInfo("en-US")),
+							   RadiansDivided = Convert.ToDecimal(tbl["RadiansDivided"], new CultureInfo("en-US")),
+							   ReducedDegrees = Convert.ToDecimal(tbl["ReducedDegrees"], new CultureInfo("en-US")),
+							   TotalMinutes = Convert.ToDecimal(tbl["TotalMinutes"], new CultureInfo("en-US")),
+							   TotalSeconds = Convert.ToDecimal(tbl["TotalSeconds"], new CultureInfo("en-US")),
+							   OppositeDirection = Convert.ToDecimal(tbl["OppositeDirection"], new CultureInfo("en-US"))
 						   }).ToArray();
 
 			return returnValue;

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Tests/SolarCalculatorTests.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Tests/SolarCalculatorTests.cs
@@ -350,5 +350,58 @@ namespace Innovative.SolarCalculator.Tests
             Assert.AreEqual(14,   solarTimes.DuskAstronomical.Second);
         }
 
+
+        [Test]
+        public void CheckPolarTimes()
+        {
+            //WIP: Solve for Polar day & Night
+            SolarTimes polarDay = new SolarTimes()
+            {
+                Latitude = 68.2627966,
+                Longitude = 14.2492450,
+                ForDate = new DateTimeOffset(new DateTime(2023, 6, 29, 12, 0, 0), TimeSpan.FromHours(2)),
+            };
+            
+            SolarTimes polarNight = new SolarTimes()
+            {
+                Latitude = 68.2627966,
+                Longitude = 14.2492450,
+                ForDate = new DateTimeOffset(new DateTime(2024, 01, 01, 12, 0, 0), TimeSpan.FromHours(1)),
+            };
+            
+            Assert.AreEqual(2023, polarNight.Sunset.Year);
+            Assert.AreEqual(12,   polarNight.Sunset.Month);
+            Assert.AreEqual(07,   polarNight.Sunset.Day);
+            Assert.AreEqual(12,   polarNight.Sunset.Hour);
+            Assert.AreEqual(05,   polarNight.Sunset.Minute);
+            Assert.AreEqual(48,   polarNight.Sunset.Second);
+            
+            Assert.AreEqual(2024, polarNight.Sunrise.Year);
+            Assert.AreEqual(01,   polarNight.Sunrise.Month);
+            Assert.AreEqual(07,   polarNight.Sunrise.Day);
+            Assert.AreEqual(11,   polarNight.Sunrise.Hour);
+            Assert.AreEqual(45,   polarNight.Sunrise.Minute);
+            Assert.AreEqual(11,   polarNight.Sunrise.Second);
+            
+            Assert.AreEqual(true, polarNight.IsPolarNight);
+            Assert.AreEqual(false, polarNight.IsPolarDay);
+            
+            Assert.AreEqual(2023, polarDay.Sunset.Year);
+            Assert.AreEqual(07,   polarDay.Sunset.Month);
+            Assert.AreEqual(21,   polarDay.Sunset.Day);
+            Assert.AreEqual(00,   polarDay.Sunset.Hour);
+            Assert.AreEqual(41,   polarDay.Sunset.Minute);
+            Assert.AreEqual(49,   polarDay.Sunset.Second);
+            
+            Assert.AreEqual(2023, polarDay.Sunrise.Year);
+            Assert.AreEqual(05,   polarDay.Sunrise.Month);
+            Assert.AreEqual(25,   polarDay.Sunrise.Day);
+            Assert.AreEqual(01,   polarDay.Sunrise.Hour);
+            Assert.AreEqual(17,   polarDay.Sunrise.Minute);
+            Assert.AreEqual(00,   polarDay.Sunrise.Second);
+            
+            Assert.AreEqual(true, polarDay.IsPolarDay);
+            Assert.AreEqual(false, polarDay.IsPolarNight);
+        }
     }
 }

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Tests/SolarCalculatorTests.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Tests/SolarCalculatorTests.cs
@@ -350,11 +350,10 @@ namespace Innovative.SolarCalculator.Tests
             Assert.AreEqual(14,   solarTimes.DuskAstronomical.Second);
         }
 
-
         [Test]
         public void CheckPolarTimes()
         {
-            //https://gml.noaa.gov/grad/solcalc/table.php?lat=68.262796&lon=14.249245&year=2023
+            // https://gml.noaa.gov/grad/solcalc/table.php?lat=68.262796&lon=14.249245&year=2023
             SolarTimes polarDay = new SolarTimes()
             {
                 Latitude = 68.2627966,
@@ -376,20 +375,19 @@ namespace Innovative.SolarCalculator.Tests
                 ForDate = new DateTimeOffset(new DateTime(2024, 02, 15, 12, 0, 0), TimeSpan.FromHours(1)),
             };
             
-            
-            //During polar night, the sunset was some time in the past, for now MinValue
+            // During polar night, the sunset was some time in the past, for now MinValue
             Assert.AreEqual(DateTime.MinValue, polarNight.Sunset);
-            //During polar night, the sunrise is some time in future, for now MaxValue
+            // During polar night, the sunrise is some time in future, for now MaxValue
             Assert.AreEqual(DateTime.MaxValue, polarNight.Sunrise);
-            //Is polar night, sun never rises
+            // Is polar night, sun never rises
             Assert.AreEqual(true, polarNight.IsPolarNight);
             Assert.AreEqual(false, polarNight.IsPolarDay);
             
-            //During polar day, the sunrise was some time in the past, for now MinValue
+            // During polar day, the sunrise was some time in the past, for now MinValue
             Assert.AreEqual(DateTime.MinValue, polarDay.Sunrise);
-            //During polar day, the sunset is some time in future, for now MaxValue
+            // During polar day, the sunset is some time in future, for now MaxValue
             Assert.AreEqual(DateTime.MaxValue, polarDay.Sunset);
-            //Is polar day, sun never goes down
+            // Is polar day, sun never goes down
             Assert.AreEqual(true, polarDay.IsPolarDay);
             Assert.AreEqual(false, polarDay.IsPolarNight);
             

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Tests/SolarCalculatorTests.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator.Tests/Tests/SolarCalculatorTests.cs
@@ -354,12 +354,12 @@ namespace Innovative.SolarCalculator.Tests
         [Test]
         public void CheckPolarTimes()
         {
-            //WIP: Solve for Polar day & Night
+            //https://gml.noaa.gov/grad/solcalc/table.php?lat=68.262796&lon=14.249245&year=2023
             SolarTimes polarDay = new SolarTimes()
             {
                 Latitude = 68.2627966,
                 Longitude = 14.2492450,
-                ForDate = new DateTimeOffset(new DateTime(2023, 6, 29, 12, 0, 0), TimeSpan.FromHours(2)),
+                ForDate = new DateTimeOffset(new DateTime(2023, 5, 29, 12, 0, 0), TimeSpan.FromHours(2)),
             };
             
             SolarTimes polarNight = new SolarTimes()
@@ -369,39 +369,32 @@ namespace Innovative.SolarCalculator.Tests
                 ForDate = new DateTimeOffset(new DateTime(2024, 01, 01, 12, 0, 0), TimeSpan.FromHours(1)),
             };
             
-            Assert.AreEqual(2023, polarNight.Sunset.Year);
-            Assert.AreEqual(12,   polarNight.Sunset.Month);
-            Assert.AreEqual(07,   polarNight.Sunset.Day);
-            Assert.AreEqual(12,   polarNight.Sunset.Hour);
-            Assert.AreEqual(05,   polarNight.Sunset.Minute);
-            Assert.AreEqual(48,   polarNight.Sunset.Second);
+            SolarTimes notPolarTime = new SolarTimes()
+            {
+                Latitude = 68.2627966,
+                Longitude = 14.2492450,
+                ForDate = new DateTimeOffset(new DateTime(2024, 02, 15, 12, 0, 0), TimeSpan.FromHours(1)),
+            };
             
-            Assert.AreEqual(2024, polarNight.Sunrise.Year);
-            Assert.AreEqual(01,   polarNight.Sunrise.Month);
-            Assert.AreEqual(07,   polarNight.Sunrise.Day);
-            Assert.AreEqual(11,   polarNight.Sunrise.Hour);
-            Assert.AreEqual(45,   polarNight.Sunrise.Minute);
-            Assert.AreEqual(11,   polarNight.Sunrise.Second);
             
+            //During polar night, the sunset was some time in the past, for now MinValue
+            Assert.AreEqual(DateTime.MinValue, polarNight.Sunset);
+            //During polar night, the sunrise is some time in future, for now MaxValue
+            Assert.AreEqual(DateTime.MaxValue, polarNight.Sunrise);
+            //Is polar night, sun never rises
             Assert.AreEqual(true, polarNight.IsPolarNight);
             Assert.AreEqual(false, polarNight.IsPolarDay);
             
-            Assert.AreEqual(2023, polarDay.Sunset.Year);
-            Assert.AreEqual(07,   polarDay.Sunset.Month);
-            Assert.AreEqual(21,   polarDay.Sunset.Day);
-            Assert.AreEqual(00,   polarDay.Sunset.Hour);
-            Assert.AreEqual(41,   polarDay.Sunset.Minute);
-            Assert.AreEqual(49,   polarDay.Sunset.Second);
-            
-            Assert.AreEqual(2023, polarDay.Sunrise.Year);
-            Assert.AreEqual(05,   polarDay.Sunrise.Month);
-            Assert.AreEqual(25,   polarDay.Sunrise.Day);
-            Assert.AreEqual(01,   polarDay.Sunrise.Hour);
-            Assert.AreEqual(17,   polarDay.Sunrise.Minute);
-            Assert.AreEqual(00,   polarDay.Sunrise.Second);
-            
+            //During polar day, the sunrise was some time in the past, for now MinValue
+            Assert.AreEqual(DateTime.MinValue, polarDay.Sunrise);
+            //During polar day, the sunset is some time in future, for now MaxValue
+            Assert.AreEqual(DateTime.MaxValue, polarDay.Sunset);
+            //Is polar day, sun never goes down
             Assert.AreEqual(true, polarDay.IsPolarDay);
             Assert.AreEqual(false, polarDay.IsPolarNight);
+            
+            Assert.AreEqual(false, notPolarTime.IsPolarDay);
+            Assert.AreEqual(false, notPolarTime.IsPolarNight);
         }
     }
 }

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/Innovative.SolarCalculator.xml
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/Innovative.SolarCalculator.xml
@@ -155,6 +155,16 @@
             (Spreadsheet Column Y)
             </summary>
         </member>
+        <member name="P:Innovative.SolarCalculator.SolarTimes.IsPolarDay">
+            <summary>
+            A phenomenon in the northernmost and southernmost regions of Earth where day lasts for more than 24 hours, sun never sets.
+            </summary>
+        </member>
+        <member name="P:Innovative.SolarCalculator.SolarTimes.IsPolarNight">
+            <summary>
+            A phenomenon in the northernmost and southernmost regions of Earth where night lasts for more than 24 hours, sun never rises.
+            </summary>
+        </member>
         <member name="P:Innovative.SolarCalculator.SolarTimes.Sunset">
             <summary>
             Sun Set Time
@@ -440,6 +450,23 @@
             </summary>
             <param name="value">The number whose square root is to be found.</param>
             <returns>The positive square root of value.</returns>
+        </member>
+        <member name="M:Innovative.SolarCalculator.Universal.Math.Clamp``1(``0,``0,``0)">
+             <summary>Returns <paramref name="value" /> clamped to the inclusive range of <paramref name="min" /> and <paramref name="max" />.</summary>
+             <param name="value">The value to be clamped.</param>
+             <param name="min">The lower bound of the result.</param>
+             <param name="max">The upper bound of the result.</param>
+             <returns>
+               <paramref name="value" /> if <paramref name="min" /> ≤ <paramref name="value" /> ≤ <paramref name="max" />.
+            
+               -or-
+            
+               <paramref name="min" /> if <paramref name="value" /> &lt; <paramref name="min" />.
+            
+               -or-
+            
+               <paramref name="max" /> if <paramref name="max" /> &lt; <paramref name="value" />.
+             </returns>
         </member>
     </members>
 </doc>

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
@@ -157,13 +157,18 @@ namespace Innovative.SolarCalculator
 			get
 			{
 				DateTime returnValue = DateTime.MinValue;
-
+				if (IsPolarNight) return new SolarTimes(this.ForDate.Date.AddDays(1), Latitude, Longitude).Sunrise;
+				else if (IsPolarDay) return new SolarTimes(this.ForDate.Date.AddDays(-1), Latitude, Longitude).Sunrise;
 				decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays - this.HourAngleSunrise * 4M / 1440M;
 				returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
 
 				return returnValue;
 			}
 		}
+		
+		public bool IsPolarDay => TimeSpan.FromDays(1) - SunlightDuration <= TimeSpan.FromMilliseconds(10);
+
+		public bool IsPolarNight => this.SunlightDuration == TimeSpan.Zero;
 
 		/// <summary>
 		/// Sun Set Time
@@ -174,7 +179,9 @@ namespace Innovative.SolarCalculator
 			get
 			{
 				DateTime returnValue = DateTime.MinValue;
-
+				
+				if (IsPolarDay) return new SolarTimes(this.ForDate.Date.AddDays(1), Latitude, Longitude).Sunset;
+				else if (IsPolarNight) return new SolarTimes(this.ForDate.Date.AddDays(-1), Latitude, Longitude).Sunset;
 				decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays + this.HourAngleSunrise * 4M / 1440M;
 				returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
 

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
@@ -157,10 +157,19 @@ namespace Innovative.SolarCalculator
 			get
 			{
 				DateTime returnValue = DateTime.MinValue;
-				if (IsPolarNight) return DateTime.MaxValue;
-				if (IsPolarDay) return DateTime.MinValue;
-				decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays - this.HourAngleSunrise * 4M / 1440M;
-				returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
+				if (IsPolarNight)
+				{
+					returnValue =  DateTime.MaxValue;
+				}
+				else if (IsPolarDay)
+				{
+					returnValue =  DateTime.MinValue;
+				}
+				else
+				{
+					decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays - this.HourAngleSunrise * 4M / 1440M;
+					returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
+				}
 
 				return returnValue;
 			}
@@ -169,13 +178,13 @@ namespace Innovative.SolarCalculator
 		/// <summary>
 		/// A phenomenon in the northernmost and southernmost regions of Earth where day lasts for more than 24 hours, sun never sets.
 		/// </summary>
-		// Due to calculations not being correct around the pole, we account for very tiny amout of incorrectness for detrmining Polar day
+		// Due to calculations not being correct around the pole, we account for very tiny amount of incorrectness for determining Polar day
 		public bool IsPolarDay => TimeSpan.FromDays(1) - this.SunlightDuration <= TimeSpan.FromMilliseconds(1);
 
 		/// <summary>
 		/// A phenomenon in the northernmost and southernmost regions of Earth where night lasts for more than 24 hours, sun never rises.
 		/// </summary>
-		// Due to calculations not being correct around the pole, we account for very tiny amout of incorrectness for detrmining Polar night
+		// Due to calculations not being correct around the pole, we account for very tiny amount of incorrectness for determining Polar night
 		public bool IsPolarNight => this.SunlightDuration <= TimeSpan.FromMilliseconds(1);
 
 		/// <summary>
@@ -188,10 +197,19 @@ namespace Innovative.SolarCalculator
 			{
 				DateTime returnValue = DateTime.MinValue;
 				
-				if (IsPolarDay) return DateTime.MaxValue;
-				if (IsPolarNight) return DateTime.MinValue;
-				decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays + this.HourAngleSunrise * 4M / 1440M;
-				returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
+				if (IsPolarDay)
+				{
+					returnValue =  DateTime.MaxValue;
+				}
+				else if (IsPolarNight)
+				{
+					returnValue =  DateTime.MinValue;
+				}
+				else
+				{
+					decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays + this.HourAngleSunrise * 4M / 1440M;
+					returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
+				}
 
 				return returnValue;
 			}

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Solar Calculator
 // Copyright(C) 2013-2022, Daniel M. Porrey. All rights reserved.
 // 
@@ -157,8 +157,8 @@ namespace Innovative.SolarCalculator
 			get
 			{
 				DateTime returnValue = DateTime.MinValue;
-				if (IsPolarNight) return new SolarTimes(this.ForDate.Date.AddDays(1), Latitude, Longitude).Sunrise;
-				else if (IsPolarDay) return new SolarTimes(this.ForDate.Date.AddDays(-1), Latitude, Longitude).Sunrise;
+				if (IsPolarNight) return DateTime.MaxValue;
+				if (IsPolarDay) return DateTime.MinValue;
 				decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays - this.HourAngleSunrise * 4M / 1440M;
 				returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
 
@@ -166,9 +166,17 @@ namespace Innovative.SolarCalculator
 			}
 		}
 		
-		public bool IsPolarDay => TimeSpan.FromDays(1) - SunlightDuration <= TimeSpan.FromMilliseconds(1);
+		/// <summary>
+		/// A phenomenon in the northernmost and southernmost regions of Earth where day lasts for more than 24 hours, sun never sets.
+		/// </summary>
+		// Due to calculations not being correct around the pole, we account for very tiny amout of incorrectness for detrmining Polar day
+		public bool IsPolarDay => TimeSpan.FromDays(1) - this.SunlightDuration <= TimeSpan.FromMilliseconds(1);
 
-		public bool IsPolarNight => this.SunlightDuration == TimeSpan.Zero;
+		/// <summary>
+		/// A phenomenon in the northernmost and southernmost regions of Earth where night lasts for more than 24 hours, sun never rises.
+		/// </summary>
+		// Due to calculations not being correct around the pole, we account for very tiny amout of incorrectness for detrmining Polar night
+		public bool IsPolarNight => this.SunlightDuration <= TimeSpan.FromMilliseconds(1);
 
 		/// <summary>
 		/// Sun Set Time
@@ -180,8 +188,8 @@ namespace Innovative.SolarCalculator
 			{
 				DateTime returnValue = DateTime.MinValue;
 				
-				if (IsPolarDay) return new SolarTimes(this.ForDate.Date.AddDays(1), Latitude, Longitude).Sunset;
-				else if (IsPolarNight) return new SolarTimes(this.ForDate.Date.AddDays(-1), Latitude, Longitude).Sunset;
+				if (IsPolarDay) return DateTime.MaxValue;
+				if (IsPolarNight) return DateTime.MinValue;
 				decimal dayFraction = (decimal)this.SolarNoon.TimeOfDay.TotalDays + this.HourAngleSunrise * 4M / 1440M;
 				returnValue = this.ForDate.Date.Add(DecimalTimeSpan.FromDays(dayFraction));
 

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/SolarTimes.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Solar Calculator
 // Copyright(C) 2013-2022, Daniel M. Porrey. All rights reserved.
 // 
@@ -166,7 +166,7 @@ namespace Innovative.SolarCalculator
 			}
 		}
 		
-		public bool IsPolarDay => TimeSpan.FromDays(1) - SunlightDuration <= TimeSpan.FromMilliseconds(10);
+		public bool IsPolarDay => TimeSpan.FromDays(1) - SunlightDuration <= TimeSpan.FromMilliseconds(1);
 
 		public bool IsPolarNight => this.SunlightDuration == TimeSpan.Zero;
 

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/UniversalMath.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/UniversalMath.cs
@@ -109,9 +109,22 @@ namespace Innovative.SolarCalculator
             /// </returns>
             private static T Clamp<T>(T value, T min, T max) where T : System.IComparable<T>
             {
-                if (value.CompareTo(min) < 0) return min;
-                else if(value.CompareTo(max) > 0) return max;
-                else return value;
+                T returnValue = default(T);
+
+                if (value.CompareTo(min) < 0)
+                {
+                    returnValue = min;
+                }
+                else if (value.CompareTo(max) > 0)
+                {
+                    returnValue = max;
+                }
+                else
+                {
+                    returnValue = value;
+                }
+
+                return returnValue;
             }
         }
     }

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/UniversalMath.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/UniversalMath.cs
@@ -15,81 +15,89 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
+
 namespace Innovative.SolarCalculator
 {
-	/// <summary>
-	/// Provides common .NET static methods that vary between versions.
-	/// </summary>
-	public static class Universal
-	{
-		/// <summary>
-		/// The Math functions in PORTABLE libraries only accept and return double. All other libraries accept
-		/// decimal. The library works in all decimal values. This class provides decimal based Math functions
-		/// for all platforms.
-		/// </summary>
-		public static class Math
-		{
-			/// <summary>
-			/// Returns the sine of the specified angle.
-			/// </summary>
-			/// <param name="value">An angle, measured in radians.</param>
-			/// <returns>The sine of value.</returns>
-			public static decimal Sin(decimal value)
-			{
-				return (decimal)System.Math.Sin((double)value);
-			}
+    /// <summary>
+    /// Provides common .NET static methods that vary between versions.
+    /// </summary>
+    public static class Universal
+    {
+        /// <summary>
+        /// The Math functions in PORTABLE libraries only accept and return double. All other libraries accept
+        /// decimal. The library works in all decimal values. This class provides decimal based Math functions
+        /// for all platforms.
+        /// </summary>
+        public static class Math
+        {
+            /// <summary>
+            /// Returns the sine of the specified angle.
+            /// </summary>
+            /// <param name="value">An angle, measured in radians.</param>
+            /// <returns>The sine of value.</returns>
+            public static decimal Sin(decimal value)
+            {
+                return (decimal)System.Math.Sin((double)value);
+            }
 
-			/// <summary>
-			/// Returns the angle whose sine is the specified number.
-			/// </summary>
-			/// <param name="value">A number representing a sine, where value must be greater
-			/// than or equal to -1, but less than or equal to 1.</param>
-			/// <returns>An angle, θ, measured in radians.</returns>
-			public static decimal Asin(decimal value)
-			{
-				return (decimal)System.Math.Asin((double)value);
-			}
+            /// <summary>
+            /// Returns the angle whose sine is the specified number.
+            /// </summary>
+            /// <param name="value">A number representing a sine, where value must be greater
+            /// than or equal to -1, but less than or equal to 1.</param>
+            /// <returns>An angle, θ, measured in radians.</returns>
+            public static decimal Asin(decimal value)
+            {
+                return (decimal)System.Math.Asin((double)value);
+            }
 
-			/// <summary>
-			/// Returns the tangent of the specified angle.
-			/// </summary>
-			/// <param name="value">An angle, measured in radians.</param>
-			/// <returns>The tangent of value.</returns>
-			public static decimal Tan(decimal value)
-			{
-				return (decimal)System.Math.Tan((double)value);
-			}
+            /// <summary>
+            /// Returns the tangent of the specified angle.
+            /// </summary>
+            /// <param name="value">An angle, measured in radians.</param>
+            /// <returns>The tangent of value.</returns>
+            public static decimal Tan(decimal value)
+            {
+                return (decimal)System.Math.Tan((double)value);
+            }
 
-			/// <summary>
-			/// Returns the cosine of the specified angle.
-			/// </summary>
-			/// <param name="value">An angle, measured in radians.</param>
-			/// <returns>The cosine of value.</returns>
-			public static decimal Cos(decimal value)
-			{
-				return (decimal)System.Math.Cos((double)value);
-			}
+            /// <summary>
+            /// Returns the cosine of the specified angle.
+            /// </summary>
+            /// <param name="value">An angle, measured in radians.</param>
+            /// <returns>The cosine of value.</returns>
+            public static decimal Cos(decimal value)
+            {
+                return (decimal)System.Math.Cos((double)value);
+            }
 
-			/// <summary>
-			/// Returns the angle whose cosine is the specified number.
-			/// </summary>
-			/// <param name="value">A number representing a cosine, where value must be greater than or equal to -1,
-			/// but less than or equal to 1.</param>
-			/// <returns>An angle, θ, measured in radians.</returns>
-			public static decimal Acos(decimal value)
-			{
-				return (decimal)System.Math.Acos((double)value);
-			}
+            /// <summary>
+            /// Returns the angle whose cosine is the specified number.
+            /// </summary>
+            /// <param name="value">A number representing a cosine, where value must be greater than or equal to -1,
+            /// but less than or equal to 1.</param>
+            /// <returns>An angle, θ, measured in radians.</returns>
+            public static decimal Acos(decimal value)
+            {
+                return (decimal)System.Math.Acos(Clamp((double)value, (double)decimal.MinusOne, (double)decimal.One));
+            }
 
-			/// <summary>
-			/// Returns the square root of a specified number.
-			/// </summary>
-			/// <param name="value">The number whose square root is to be found.</param>
-			/// <returns>The positive square root of value.</returns>
-			public static decimal Sqrt(decimal value)
-			{
-				return (decimal)System.Math.Sqrt((double)value);
-			}
-		}
-	}
+            /// <summary>
+            /// Returns the square root of a specified number.
+            /// </summary>
+            /// <param name="value">The number whose square root is to be found.</param>
+            /// <returns>The positive square root of value.</returns>
+            public static decimal Sqrt(decimal value)
+            {
+                return (decimal)System.Math.Sqrt((double)value);
+            }
+			
+            private static T Clamp<T>(T val, T min, T max) where T : System.IComparable<T>
+            {
+                if (val.CompareTo(min) < 0) return min;
+                else if(val.CompareTo(max) > 0) return max;
+                else return val;
+            }
+        }
+    }
 }

--- a/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/UniversalMath.cs
+++ b/Src/Solar-Calculator-Solution/Innovative.SolarCalculator/UniversalMath.cs
@@ -48,7 +48,7 @@ namespace Innovative.SolarCalculator
             /// <returns>An angle, θ, measured in radians.</returns>
             public static decimal Asin(decimal value)
             {
-                return (decimal)System.Math.Asin((double)value);
+                return (decimal)System.Math.Asin(Clamp((double)value, (double)decimal.MinusOne, (double)decimal.One));
             }
 
             /// <summary>
@@ -92,11 +92,26 @@ namespace Innovative.SolarCalculator
                 return (decimal)System.Math.Sqrt((double)value);
             }
 			
-            private static T Clamp<T>(T val, T min, T max) where T : System.IComparable<T>
+            /// <summary>Returns <paramref name="value" /> clamped to the inclusive range of <paramref name="min" /> and <paramref name="max" />.</summary>
+            /// <param name="value">The value to be clamped.</param>
+            /// <param name="min">The lower bound of the result.</param>
+            /// <param name="max">The upper bound of the result.</param>
+            /// <returns>
+            ///   <paramref name="value" /> if <paramref name="min" /> ≤ <paramref name="value" /> ≤ <paramref name="max" />.
+            ///
+            ///   -or-
+            ///
+            ///   <paramref name="min" /> if <paramref name="value" /> &lt; <paramref name="min" />.
+            ///
+            ///   -or-
+            ///
+            ///   <paramref name="max" /> if <paramref name="max" /> &lt; <paramref name="value" />.
+            /// </returns>
+            private static T Clamp<T>(T value, T min, T max) where T : System.IComparable<T>
             {
-                if (val.CompareTo(min) < 0) return min;
-                else if(val.CompareTo(max) > 0) return max;
-                else return val;
+                if (value.CompareTo(min) < 0) return min;
+                else if(value.CompareTo(max) > 0) return max;
+                else return value;
             }
         }
     }


### PR DESCRIPTION
Solves: #6

This is solved by making sure that we don't create double.NaN when calculating invalid values. Since the base of the calculations kind of falls apart at the poles. Polar day/night is calulated by checking the duration of the day. There might be a better solution in which you could check the angle of which the sun rises at, but that would require a bit more effort.

This PR adds a two new properties indicating is it is polar day or polar night. Also returns DateTime.MinValue / DateTime.MaxValue for Sunrise/Sunset in the case of polar day/night.

Couldn't run the tests without fixing culture issues with parsing the CSV/Excel files so added that aswell.

Sorry about the formating of Math. Can revert that if it's a issue. 